### PR TITLE
Fix make build for fresh systems

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,7 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=acsengine
-undefine TF_ACC
+# undefine TF_ACC
 # TF_LOG=INFO
 
 ###############################################################################


### PR DESCRIPTION
This will fix temporary the make build command.

Otherwise you will see the following error message:

```bash
GNUmakefile:4: *** missing separator.  Stop.
```

Signed-off-by: solidnerd <niclas@mietz.io>